### PR TITLE
Fix navigation when launching from reminder notification

### DIFF
--- a/lib/core/notifications/local_notification_service.dart
+++ b/lib/core/notifications/local_notification_service.dart
@@ -28,7 +28,7 @@ class LocalNotificationService {
       FlutterLocalNotificationsPlugin();
   final NotificationTapCallback _onReminderTap;
 
-  Future<void> initialize() async {
+  Future<bool> initialize() async {
     await _configureTimeZones();
     await _requestPermissions();
 
@@ -59,9 +59,7 @@ class LocalNotificationService {
 
     final launchDetails = await _plugin.getNotificationAppLaunchDetails();
     final payload = launchDetails?.notificationResponse?.payload;
-    if (payload == _dailyReminderPayload) {
-      await _onReminderTap();
-    }
+    return payload == _dailyReminderPayload;
   }
 
   Future<void> scheduleDailyReminder() async {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -82,7 +82,7 @@ void main() async {
   final notificationService = LocalNotificationService(
     onReminderTap: _handleReminderTap,
   );
-  await notificationService.initialize();
+  final launchedFromReminder = await notificationService.initialize();
   await notificationService.scheduleDailyReminder();
 
   runApp(
@@ -99,6 +99,12 @@ void main() async {
       child: const MyApp(),
     ),
   );
+
+  if (launchedFromReminder) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      unawaited(_handleReminderTap());
+    });
+  }
 }
 
 class MyApp extends StatelessWidget {


### PR DESCRIPTION
## Summary
- make the local notification service report whether the app was launched from the reminder payload
- defer the reminder navigation until after the widget tree is ready to avoid blank screens on cold start

## Testing
- not run (Flutter SDK not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69109caa77188320a4cda7e0dbb2c4ad)