### PR TITLE
Preload ads when launching from notifications

### DIFF
--- a/lib/features/ads/ad_service.dart
+++ b/lib/features/ads/ad_service.dart
@@ -4,10 +4,17 @@ import 'dart:math';
 import 'package:flutter/foundation.dart';
 
 class AdService {
+  AdService._internal();
+
+  static final AdService _instance = AdService._internal();
+
+  factory AdService() => _instance;
+
   InterstitialAd? _interstitialAd;
   int _adLoadAttempts = 0;
   final int maxFailedLoadAttempts = 3;
   bool _isAdLoaded = false;
+  bool _isLoadingAd = false;
 
   // IDs de anuncios - distinción entre desarrollo y producción
   static final String interstitialAdUnitId = _getAdUnitId();
@@ -35,6 +42,17 @@ class AdService {
   }
 
   void loadInterstitialAd() {
+    if (_isAdLoaded) {
+      print('AdService: ✅ Ad already loaded, skipping new load');
+      return;
+    }
+
+    if (_isLoadingAd) {
+      print('AdService: ⏳ Ad is currently loading, skipping duplicate call');
+      return;
+    }
+
+    _isLoadingAd = true;
     final environment = kDebugMode ? 'DESARROLLO (PRUEBA)' : 'PRODUCCIÓN';
     print('AdService: 🔄 Loading interstitial ad...');
     print('AdService: Environment: $environment');
@@ -52,6 +70,7 @@ class AdService {
           _interstitialAd = ad;
           _adLoadAttempts = 0; // Resetear intentos en carga exitosa
           _isAdLoaded = true;
+          _isLoadingAd = false;
         },
         onAdFailedToLoad: (LoadAdError error) {
           print(
@@ -62,6 +81,7 @@ class AdService {
           _adLoadAttempts++;
           _interstitialAd = null;
           _isAdLoaded = false;
+          _isLoadingAd = false;
           if (_adLoadAttempts <= maxFailedLoadAttempts) {
             print(
                 'AdService: 🔄 Retrying to load ad (attempt $_adLoadAttempts/$maxFailedLoadAttempts)');

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:path_provider/path_provider.dart';
 import 'core/notifications/local_notification_service.dart';
+import 'features/ads/ad_service.dart';
 import 'features/mood/data/models/mood_model.dart';
 import 'features/mood/data/repositories/mood_repository_impl.dart';
 import 'features/mood/domain/usecases/save_mood_usecase.dart';
@@ -58,6 +59,7 @@ void main() async {
       name: 'Main',
       level: 800,
     );
+    AdService().loadInterstitialAd();
   } catch (e) {
     developer.log(
       'Error initializing Google Mobile Ads',


### PR DESCRIPTION
## Summary
- turn the ad service into a singleton, prevent duplicated load calls, and keep track of the current loading state
- preload the interstitial ad right after Mobile Ads is initialized so it is already available when the mood screen is opened from a reminder

## Testing
- `flutter test` *(fails: Flutter SDK is not available in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919e80bd14083208386879c4386ce98)